### PR TITLE
panel-plugin/title/windowck-title.c: fix memory leak on title change

### DIFF
--- a/panel-plugin/title/windowck-title.c
+++ b/panel-plugin/title/windowck-title.c
@@ -169,7 +169,7 @@ static void on_name_changed (WnckWindow *controlwindow, WindowckPlugin *wckp)
             {
                 if (wckp->prefs->two_lines)
                 {
-                    gchar *subtitle = malloc( sizeof(gchar) * ( strlen(title_text) + 1 ) );
+                    gchar *subtitle = g_malloc( sizeof(gchar) * ( strlen(title_text) + 1 ) );
                     strcpy (subtitle, part[0]);
                     if (wckp->prefs->full_name)
                     {


### PR DESCRIPTION
It seems the memory is allocated on every title change and never gets
freed. Glib says to use g_malloc() with g_free() (used below) and it
seems switching to g_malloc() fixes the memory leak.

Refs https://github.com/cedl38/xfce4-windowck-plugin/issues/30

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>